### PR TITLE
Set Q4 as default quantization

### DIFF
--- a/source/infer.py
+++ b/source/infer.py
@@ -30,7 +30,7 @@ class Stage1Config:
 class Stage2Config:
     model_path: str = "models/YuE-s2-1B-general-exl2"
     cache_size: int = 7500
-    cache_mode: str = "FP16"
+    cache_mode: str = "Q4"
 
 @dataclass
 class PostProcessConfig:

--- a/source/ui.py
+++ b/source/ui.py
@@ -148,7 +148,7 @@ class AppMain:
     DefaultStage1CacheMode: str = "Q4"
 
     DefaultStage2Model: str = "YuE-s2-1B-general-exl2"
-    DefaultStage2CacheMode: str = "FP16"
+    DefaultStage2CacheMode: str = "Q4"
 
     def __init__(self,
                  server_name: str = "127.0.0.1",


### PR DESCRIPTION
## Summary
- default to Q4 quantization for Stage 2 in the inference configuration and UI

## Testing
- `python -m compileall -q source`

------
https://chatgpt.com/codex/tasks/task_e_6849ed71bcb4832593512a8cb3a78604