### PR TITLE
Change interface title to Hackathon Music Generator

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -428,8 +428,8 @@ class AppMain:
         <script type="module" src="/gradio_api/file=scripts/utils.js"></script>
         """
 
-        with gr.Blocks(head=head, css=css, title="YuE - UI", theme=theme) as interface:
-            gr.Markdown("# YuE - UI")
+        with gr.Blocks(head=head, css=css, title="Hackathon Music Generator", theme=theme) as interface:
+            gr.Markdown("# Hackathon Music Generator")
 
             self.create_states()
 


### PR DESCRIPTION
## Summary
- rename YuE UI to Hackathon Music Generator on the main interface page

## Testing
- `python source/ui.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6849edb1f5f88325af01043802814177