### PR TITLE
Add queue options for UI concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Run `start_windows.bat` to start the gradio server
 Linux:\
 Run `./start_linux.sh` to start the gradio server
 
+Both scripts accept optional arguments to configure queue behavior:
+
+```bash
+./start_linux.sh --concurrent_run 4 --max_queue 16
+```
+`--concurrent_run` specifies how many requests run in parallel before queuing begins.
+`--max_queue` defines the maximum queue size. When the limit is reached new requests are rejected with a message inviting you to try later.
+
 After starting the gradio server open http://127.0.0.1:7860 in your browser to access the UI.
 
 ## Generating music

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Both scripts accept optional arguments to configure queue behavior:
 ```
 `--concurrent_run` specifies how many requests run in parallel before queuing begins.
 `--max_queue` defines the maximum queue size. When the limit is reached new requests are rejected with a message inviting you to try later.
+The defaults are 4 concurrent runs and a queue limit of 16, so passing no options uses these values.
 
 After starting the gradio server open http://127.0.0.1:7860 in your browser to access the UI.
 

--- a/source/ui.py
+++ b/source/ui.py
@@ -154,11 +154,15 @@ class AppMain:
                  server_name: str = "127.0.0.1",
                  server_port: int = 7860,
                  working_directory: str = "",
+                 concurrent_run: int = 4,
+                 max_queue: int = 16,
                  ):
         
         self._server_name = server_name
         self._server_port = server_port
         self._working_directory = working_directory
+        self._concurrent_run = concurrent_run
+        self._max_queue = max_queue
 
         os.environ["GRADIO_TEMP_DIR"] = os.path.abspath(os.path.join(self._working_directory, "tmp"))
 
@@ -171,6 +175,11 @@ class AppMain:
 
         self._component_serializers = {}
         self._interface = self.create_interface()
+        self._interface.queue(
+            default_concurrency_limit=self._concurrent_run,
+            max_size=self._max_queue,
+            status_update_rate=1,
+        )
 
     def save_state(self, *args):
         output = {}
@@ -1549,6 +1558,11 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--server_name", type=str, default="127.0.0.1", help="The address to host YuE-UI gradio interface on")
     parser.add_argument("--server_port", type=int, default=7860, help="The port to host YuE-UI gradio interface on")
+    parser.add_argument("--concurrent_run", type=int, default=4, help="Number of concurrent runs before queuing")
+    parser.add_argument("--max_queue", type=int, default=16, help="Maximum queue size")
     args = parser.parse_args()
-    app = AppMain(server_name=args.server_name, server_port=args.server_port)
+    app = AppMain(server_name=args.server_name,
+                  server_port=args.server_port,
+                  concurrent_run=args.concurrent_run,
+                  max_queue=args.max_queue)
     app.launch()

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -1,2 +1,2 @@
 call ./venv/scripts/activate
-python source/ui.py
+python source/ui.py %*


### PR DESCRIPTION
## Summary
- add optional `--concurrent_run` and `--max_queue` parameters for controlling how many requests run concurrently and the queue size
- update Windows start script to forward command line arguments
- document queue options in README and fix typo

## Testing
- `python -m py_compile source/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6849ca87a528832598ec5be688eb4828