### PR TITLE
Fix Stage 1 cache overflow

### DIFF
--- a/source/yue/infer_stage1.py
+++ b/source/yue/infer_stage1.py
@@ -337,6 +337,13 @@ class Stage1Pipeline_EXL2(Stage1Pipeline):
 
         # Prepare start context
         start_context = torch.tensor([start_context] * bsz, dtype=torch.long)
+        if start_context.shape[-1] > self.cache_size:
+            print(
+                f"Start context length {start_context.shape[-1]} exceeds cache "
+                f"size {self.cache_size}, trimming context."
+            )
+            start_context = self.shorten_input(start_context, self.cache_size)
+
         seq = torch.cat((seq, start_context), dim=-1)
 
         nr_generated = 0


### PR DESCRIPTION
## Summary
- trim Stage 1 start context when it exceeds cache capacity

## Testing
- `python -m compileall -q source`

------
https://chatgpt.com/codex/tasks/task_e_6849ee5d610483259ab97bfaeab35f93