### PR TITLE
Keep newest segments when handling truncated context

### DIFF
--- a/source/yue/infer_stage1.py
+++ b/source/yue/infer_stage1.py
@@ -204,8 +204,15 @@ class Stage1Pipeline:
         ids = raw_output[0].cpu().numpy()
         soa_idx = np.where(ids == self.mmtokenizer.soa)[0].tolist()
         eoa_idx = np.where(ids == self.mmtokenizer.eoa)[0].tolist()
-        if len(soa_idx) != len(eoa_idx):
-            raise ValueError(f"invalid pairs of soa and eoa, Num of soa: {len(soa_idx)}, Num of eoa: {len(eoa_idx)}")
+
+        # Sometimes context truncation can lead to unmatched soa/eoa tokens.
+        # Drop any leading EOAs and truncate the oldest unmatched SOAs so that
+        # the newest segments are preserved.
+        while soa_idx and eoa_idx and eoa_idx[0] < soa_idx[0]:
+            eoa_idx.pop(0)
+        pair_len = min(len(soa_idx), len(eoa_idx))
+        soa_idx = soa_idx[-pair_len:] if pair_len else []
+        eoa_idx = eoa_idx[-pair_len:] if pair_len else []
 
         vocals = []
         instrumentals = []
@@ -237,8 +244,14 @@ class Stage1Pipeline:
 
         soa_idx = np.where(ids == self.mmtokenizer.soa)[0].tolist()
         eoa_idx = np.where(ids == self.mmtokenizer.eoa)[0].tolist()
-        if len(soa_idx) != len(eoa_idx):
-            raise ValueError(f"invalid pairs of soa and eoa, Num of soa: {len(soa_idx)}, Num of eoa: {len(eoa_idx)}")
+
+        # Drop unmatched leading EOAs and truncate oldest unmatched pairs so the
+        # most recent segments remain intact
+        while soa_idx and eoa_idx and eoa_idx[0] < soa_idx[0]:
+            eoa_idx.pop(0)
+        pair_len = min(len(soa_idx), len(eoa_idx))
+        soa_idx = soa_idx[-pair_len:] if pair_len else []
+        eoa_idx = eoa_idx[-pair_len:] if pair_len else []
 
         range_begin = 1 if skip_first_block else 0
         sep_len = len(self.codec_tool.sep_ids)


### PR DESCRIPTION
## Summary
- drop unmatched tokens from the beginning of stage1 output so we keep the latest segments

## Testing
- `python -m py_compile source/yue/infer_stage1.py`


------
https://chatgpt.com/codex/tasks/task_e_684a1014566883259307633759b2f5ff