### PR TITLE
Add root_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Both scripts accept optional arguments to configure queue behaviour:
 ```
 `--concurrent_run` specifies how many requests run in parallel before queuing begins.
 `--max_queue` defines the maximum queue size. When the limit is reached new requests are rejected with a message inviting you to try later.
+You can also specify a root path when running behind a reverse proxy:
+```bash
+./start_linux.sh --root_path /music
+```
+
 
 After starting the gradio server open http://127.0.0.1:7860 in your browser to access the UI.
 

--- a/source/ui.py
+++ b/source/ui.py
@@ -156,6 +156,7 @@ class AppMain:
                  working_directory: str = "",
                  concurrent_run: int = 4,
                  max_queue: int = 16,
+                 root_path: str | None = None,
                  ):
         
         self._server_name = server_name
@@ -163,6 +164,7 @@ class AppMain:
         self._working_directory = working_directory
         self._concurrent_run = concurrent_run
         self._max_queue = max_queue
+        self._root_path = root_path
 
         os.environ["GRADIO_TEMP_DIR"] = os.path.abspath(os.path.join(self._working_directory, "tmp"))
 
@@ -1552,7 +1554,12 @@ class AppMain:
         )
 
     def launch(self):
-        self._interface.launch(server_name=self._server_name, server_port=self._server_port, allowed_paths=self._allowed_paths)
+        self._interface.launch(
+            server_name=self._server_name,
+            server_port=self._server_port,
+            allowed_paths=self._allowed_paths,
+            root_path=self._root_path,
+        )
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -1560,9 +1567,11 @@ if __name__ == "__main__":
     parser.add_argument("--server_port", type=int, default=7860, help="The port to host YuE-UI gradio interface on")
     parser.add_argument("--concurrent_run", type=int, default=4, help="Number of concurrent runs before queuing")
     parser.add_argument("--max_queue", type=int, default=16, help="Maximum queue size")
+    parser.add_argument("--root_path", type=str, default="", help="Root path for running behind a proxy, e.g. /music")
     args = parser.parse_args()
     app = AppMain(server_name=args.server_name,
                   server_port=args.server_port,
                   concurrent_run=args.concurrent_run,
-                  max_queue=args.max_queue)
+                  max_queue=args.max_queue,
+                  root_path=args.root_path if args.root_path else None)
     app.launch()


### PR DESCRIPTION
## Summary
- make a new `--root_path` argument available in `ui.py`
- pass the new value through `AppMain.launch()` to gradio
- document the usage in `README.md`

## Testing
- `python -m py_compile source/ui.py`
- *(fails: ModuleNotFoundError: No module named 'torch')* when trying to run `python source/ui.py --root_path /music --help`

------
https://chatgpt.com/codex/tasks/task_e_684c0a1057408325bd93155db703c907