### PR TITLE
Fix mixed content when app is behind SSL offloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ You can also specify a root path when running behind a reverse proxy:
 ./start_linux.sh --root_path /music
 ```
 
+If your proxy terminates SSL (HTTPS) before forwarding requests to YuE-UI, set
+the environment variable `FORCE_HTTPS=true` when launching the server. This
+forces all generated file URLs to use the HTTPS scheme to avoid mixed content
+warnings in browsers.
+
 
 After starting the gradio server open http://127.0.0.1:7860 in your browser to access the UI.
 

--- a/source/ui.py
+++ b/source/ui.py
@@ -19,6 +19,19 @@ from gradio_vistimeline import VisTimeline, VisTimelineData
 from tqdm import tqdm
 import torch
 
+import gradio.route_utils as gr_route_utils
+
+if os.getenv("FORCE_HTTPS", "false").lower() == "true":
+    _orig_get_root_url = gr_route_utils.get_root_url
+
+    def _https_root_url(request, route_path, root_path):
+        url = _orig_get_root_url(request, route_path, root_path)
+        if url.startswith("http://"):
+            url = "https://" + url[len("http://"):]
+        return url
+
+    gr_route_utils.get_root_url = _https_root_url
+
 def date_to_milliseconds(date):
     try:
         date = int(date)


### PR DESCRIPTION
## Summary
- allow forcing HTTPS for all generated URLs
- document the `FORCE_HTTPS` environment variable

## Testing
- `python -m py_compile source/ui.py`

------
https://chatgpt.com/codex/tasks/task_e_684cc8137b048325abcdfb12b448eaa4