### PR TITLE
Fix relative paths for frontend scripts

### DIFF
--- a/scripts/audioplayer.js
+++ b/scripts/audioplayer.js
@@ -1,4 +1,4 @@
-import WaveSurfer from '/gradio_api/file=scripts/wavesurfer.esm.js'
+import WaveSurfer from './wavesurfer.esm.js'
 
 class WaveSurferPlayer {
   constructor(player_container) {

--- a/source/ui.py
+++ b/source/ui.py
@@ -438,9 +438,9 @@ class AppMain:
             css = file.read()
 
         head="""
-        <script type="module" src="/gradio_api/file=scripts/wavesurfer.esm.js"></script>
-        <script type="module" src="/gradio_api/file=scripts/audioplayer.js"></script>
-        <script type="module" src="/gradio_api/file=scripts/utils.js"></script>
+        <script type="module" src="gradio_api/file=scripts/wavesurfer.esm.js"></script>
+        <script type="module" src="gradio_api/file=scripts/audioplayer.js"></script>
+        <script type="module" src="gradio_api/file=scripts/utils.js"></script>
         """
 
         with gr.Blocks(head=head, css=css, title="Hackathon Music Generator", theme=theme) as interface:


### PR DESCRIPTION
## Summary
- fix script tag URLs to respect root_path
- adjust module import path in audioplayer

## Testing
- `python -m py_compile source/ui.py`

------
https://chatgpt.com/codex/tasks/task_e_684ccb0b8b808325980c109b6bd5d765