### PR TITLE
Fix gradio interface load event

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -205,13 +205,6 @@ class AppMain:
             status_update_rate=1,
         )
 
-        # Ensure defaults are applied on every page refresh
-        self._interface.load(
-            fn=self.load_default_config,
-            inputs=None,
-            outputs=self.serialized_components()
-        )
-
     def save_state(self, *args):
         output = {}
 
@@ -511,6 +504,12 @@ class AppMain:
             self._simple_audio
 
             self.create_simple_events()
+
+            interface.load(
+                fn=self.load_default_config,
+                inputs=None,
+                outputs=self.serialized_components(),
+            )
 
         return interface
 


### PR DESCRIPTION
## Summary
- fix 'Cannot call load outside of a gradio.Blocks context' by registering the
  load handler while building the Blocks interface

## Testing
- `python -m py_compile source/ui.py`

------
https://chatgpt.com/codex/tasks/task_e_684d98186b1c8325be3f1261a21f2a2f